### PR TITLE
Fix not handling rejection by all relays correctly in test

### DIFF
--- a/test/flows_test.js
+++ b/test/flows_test.js
@@ -134,7 +134,9 @@ options.forEach(params => {
                 ex = e
             }
             assert.ok(ex != null, "Expected to throw " + msg + " but threw nothing")
-            assert.ok(ex.toString().includes(msg), "Expected to throw " + msg + " but threw " + ex.message)
+            let isExpectedError = ex.toString().includes(msg)
+                                || (ex.otherErrors != null && ex.otherErrors.length > 0 && ex.otherErrors[0].toString().includes(msg))
+            assert.ok(isExpectedError, "Expected to throw " + msg + " but threw " + ex.message)
         }
 
     })  //of contract


### PR DESCRIPTION
Currently, errors returned by individual relays get injected into the
main exception in a 'otherErrors' field.
This was not handled by this test and it would fail to see that the
reason for failure was indeed a revert.